### PR TITLE
Create project with `no-unsafe-query` rule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+
+node_js:
+  - 4
+  - 6
+
+sudo: false

--- a/README.md
+++ b/README.md
@@ -1,0 +1,83 @@
+# eslint-plugin-sql-template
+
+ESLint plugin with rules for using the `sql` template tag from a library such as [sequelize-sql-tag](https://github.com/seegno/sequelize-sql-tag) on raw SQL queries.
+
+That library escapes data provided to an SQL query statement via interpolation. This prevents, for instance, potential SQL injection attacks.
+
+This ESLint plugin helps teams enforce the usage of that tag, to avoid overlooked vulnerabilities from creeping into their codebases.
+
+## Installation
+
+```sh
+$ npm install eslint eslint-plugin-sql-template --save-dev
+```
+
+## Usage
+
+Create an `.eslint.yml` file with the following:
+
+```yaml
+plugins:
+  - sql-template
+```
+
+Then, you can add the custom rules to the `.eslint.yml` file:
+
+```yaml
+rules:
+  - sql-template/no-unsafe-query: 2
+```
+
+To lint your project with ESLint, add the following `script` to your `package.json`:
+
+```json
+{
+  "scripts": {
+    "lint": "eslint ."
+  }
+}
+```
+
+and run the linter with:
+
+```sh
+$ npm run lint
+```
+
+## Rules
+
+This plugin includes the following list of rules.
+
+### `no-unsafe-query`
+
+Disallows the usage of raw SQL templates with interpolation when not protected with the `sql` tag. Use this rule when you want to enforce protection against SQL injection attacks on all queries.
+
+#### Example
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint sql-template/no-unsafe-query: "error"*/
+
+const value = 42;
+const query = `SELECT * FROM users WHERE id = ${value}`;
+db.query(query);
+
+const columns = 'id, name';
+Users.query(`SELECT ${columns} FROM users`);
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint sql-template/no-unsafe-query: "error"*/
+
+const value = 42;
+const query = sql`SELECT * FROM users WHERE id = ${value}`;
+db.query(query);
+
+Users.query(`SELECT id, name FROM users`);
+
+const punctuation = '!';
+foo.bar(`Not SQL${punctuation}`);
+```

--- a/index.js
+++ b/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * Export rules.
+ */
+
+module.exports.rules = {
+  'no-unsafe-query': require('./rules/no-unsafe-query')
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "eslint-plugin-sql-template",
+  "version": "1.0.0",
+  "description": "ESLint plugin with rules for using the `sql` template tag on raw SQL queries",
+  "keywords": [
+    "plugin",
+    "eslint",
+    "lint",
+    "shared",
+    "tag",
+    "sql",
+    "sql-tag",
+    "string",
+    "template"
+  ],
+  "homepage": "https://github.com/uphold/eslint-plugin-sql-template#readme",
+  "bugs": "https://github.com/uphold/eslint-plugin-sql-template/issues",
+  "license": "MIT",
+  "author": "Uphold",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/uphold/eslint-plugin-sql-template.git"
+  },
+  "dependencies": {
+    "lodash": "^4.16.2",
+    "sql-parse": "^0.1.5"
+  },
+  "engines": {
+    "node": ">=4"
+  },
+  "scripts": {
+    "changelog": "github_changelog_generator --header-label '# Changelog' --no-issues --no-verbose --future-release=$npm_config_future_release && sed -i '' -e :a -e '$d;N;2,3ba' -e 'P;D' CHANGELOG.md",
+    "test": "mocha ./test/**/*.js",
+    "version": "npm run changelog --future-release=$npm_package_version && git add -A CHANGELOG.md"
+  },
+  "devDependencies": {
+    "eslint": "^3.6.1",
+    "mocha": "^3.1.0"
+  }
+}

--- a/rules/no-unsafe-query.js
+++ b/rules/no-unsafe-query.js
@@ -1,0 +1,61 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const _ = require('lodash');
+const parser = require('sql-parse');
+
+/**
+ * Check if `literal` is an SQL query.
+ */
+
+function isSqlQuery(literal) {
+  if (!literal) {
+    return false;
+  }
+
+  try {
+    parser.parse(literal);
+  } catch (error) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Validate node.
+ */
+
+function validate(node, context) {
+  if (!node) {
+    return;
+  }
+
+  if (node.type === 'TaggedTemplateExpression' && node.tag.name !== 'sql') {
+    node = node.quasi;
+  }
+
+  if (node.type === 'TemplateLiteral' && node.expressions.length) {
+    const literal = _.map(node.quasis, 'value.raw').join('x');
+
+    if (isSqlQuery(literal)) {
+      context.report(node, 'Use the `sql` tagged template literal for raw queries');
+    }
+  }
+}
+
+/**
+ * Export `no-unsafe-query`.
+ */
+
+module.exports = context => ({
+  CallExpression(node) {
+    node.arguments.forEach(argument => validate(argument, context));
+  },
+  VariableDeclaration(node) {
+    node.declarations.forEach(declaration => validate(declaration.init, context));
+  }
+});

--- a/test/rules/no-unsafe-query_test.js
+++ b/test/rules/no-unsafe-query_test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../../rules/no-unsafe-query');
+
+RuleTester.setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 6
+  }
+});
+
+/**
+ * Test `no-unsafe-query`.
+ */
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unsafe-query', rule, {
+  invalid: [{
+    code: 'const column = "*"; foo.query(`SELECT ${column} FROM foobar`);',
+    errors: [{
+      message: 'Use the `sql` tagged template literal for raw queries'
+    }]
+  }, {
+    code: 'const column = "*"; const query = `SELECT ${column} FROM foobar`; foo.query(query);',
+    errors: [{
+      message: 'Use the `sql` tagged template literal for raw queries'
+    }]
+  }, {
+    code: 'const column = "*"; foo.query(foobar`SELECT ${column} FROM foobar`);',
+    errors: [{
+      message: 'Use the `sql` tagged template literal for raw queries'
+    }]
+  }, {
+    code: 'const column = "*"; const query = foobar`SELECT ${column} FROM foobar`; foo.query(query);',
+    errors: [{
+      message: 'Use the `sql` tagged template literal for raw queries'
+    }]
+  }],
+  valid: [
+    'const column = "*"; foo.query(sql`SELECT ${column} FROM foobar`);',
+    'const column = "*"; const query = sql`SELECT ${column} FROM foobar`; foo.query(query);',
+    'foo.query(`SELECT column FROM foobar`);',
+    'const query = `SELECT column FROM foobar`; foo.query(query);',
+    'const foo = "bar"; baz.greet(`hello ${foo}`);',
+    'const foo = "bar"; const baz = `hello ${foo}`; qux.greet(baz);',
+    'foo.greet(`hello`);',
+    'const foo = `bar`; baz.greet(foo);'
+  ]
+});


### PR DESCRIPTION
Create new ESLint plugin to add rules for the usage of the `sql` template tag. This makes it possible to flag potential uses of raw queries that aren't being sanitised. Include the new `no-unsafe-query` rule to deal with those situations.
