### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eslint-plugin-sql-template
 
-ESLint plugin with rules for using the `sql` template tag from a library such as [sequelize-sql-tag](https://github.com/seegno/sequelize-sql-tag) on raw SQL queries.
+ESLint plugin with rules for using the `sql` template tag from a library such as [sql-tag](https://github.com/seegno/sql-tag) on raw SQL queries.
 
 That library escapes data provided to an SQL query statement via interpolation. This prevents, for instance, potential SQL injection attacks.
 


### PR DESCRIPTION
Suggest `sql-tag` instead of `sequelize-sql-tag` in the docs.
