### PR TITLE
chore: use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Uphold",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/uphold/eslint-plugin-sql-template.git"
+    "url": "git+https://github.com/uphold/eslint-plugin-sql-template.git"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary

- update the package repository metadata to use the public HTTPS GitHub URL instead of SSH

## Validation

- Parsed `package.json` and asserted `repository.url` is `git+https://github.com/uphold/eslint-plugin-sql-template.git`
- `git diff --check`
- `git ls-remote https://github.com/uphold/eslint-plugin-sql-template.git HEAD`
- `pnpm install --ignore-scripts --lockfile=false`
- `pnpm test`
- `pnpm lint`
- `pnpm pack --dry-run`
